### PR TITLE
Fix layout issues with the empty states

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,20 +1,11 @@
 export function EmptyState() {
   return (
-    <div className="mx-auto max-w-4xl py-16 text-center">
+    <div className="mx-auto max-w-4xl py-8 text-center">
       <h2 className="mb-4 font-semibold text-2xl">No comments open</h2>
       <p className="mb-6 text-gray-600">
         Your drafts will appear here when you start typing in comment boxes
         across GitHub and Reddit.
       </p>
-      <div className="space-y-2">
-        <button type="button" className="text-blue-600 hover:underline">
-          How it works
-        </button>
-        <span className="mx-2">·</span>
-        <button type="button" className="text-blue-600 hover:underline">
-          Check permissions
-        </button>
-      </div>
     </div>
   )
 }

--- a/src/components/NoMatchesState.tsx
+++ b/src/components/NoMatchesState.tsx
@@ -8,7 +8,7 @@ export function NoMatchesState({ onClearFilters }: NoMatchesStateProps) {
       <button
         type="button"
         onClick={onClearFilters}
-        className="text-blue-600 hover:underline cursor-pointer"
+        className="cursor-pointer text-blue-600 hover:underline"
       >
         Clear filters
       </button>

--- a/src/components/NoMatchesState.tsx
+++ b/src/components/NoMatchesState.tsx
@@ -3,12 +3,12 @@ type NoMatchesStateProps = {
 }
 export function NoMatchesState({ onClearFilters }: NoMatchesStateProps) {
   return (
-    <div className="py-16 text-center">
+    <div className="py-8 text-center">
       <p className="mb-4 text-gray-600">No matches found</p>
       <button
         type="button"
         onClick={onClearFilters}
-        className="text-blue-600 hover:underline"
+        className="text-blue-600 hover:underline cursor-pointer"
       >
         Clear filters
       </button>

--- a/src/components/PopupRoot.tsx
+++ b/src/components/PopupRoot.tsx
@@ -101,28 +101,8 @@ export function PopupRoot({ drafts }: PopupRootProps) {
     })
   }
 
-  const getTableBody = () => {
-    if (drafts.length === 0) {
-      return <EmptyState />
-    }
-
-    if (
-      filteredDrafts.length === 0 &&
-      (filters.searchQuery || filters.sentFilter !== "both")
-    ) {
-      return <NoMatchesState onClearFilters={clearFilters} />
-    }
-
-    return filteredDrafts.map((row) => (
-      <CommentRow
-        key={row.spot.unique_key}
-        row={row}
-        selectedIds={selectedIds}
-        toggleSelection={toggleSelection}
-        handleOpen={handleOpen}
-        handleTrash={handleTrash}
-      />
-    ))
+  if (drafts.length === 0) {
+    return <EmptyState />
   }
 
   return (
@@ -233,7 +213,25 @@ export function PopupRoot({ drafts }: PopupRootProps) {
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">{getTableBody()}</tbody>
+          <tbody className="divide-y divide-gray-200">
+            {filteredDrafts.length === 0 && (
+              <tr>
+                <td colSpan={2}>
+                  <NoMatchesState onClearFilters={clearFilters} />
+                </td>
+              </tr>
+            )}
+            {filteredDrafts.map((row) => (
+              <CommentRow
+                key={row.spot.unique_key}
+                row={row}
+                selectedIds={selectedIds}
+                toggleSelection={toggleSelection}
+                handleOpen={handleOpen}
+                handleTrash={handleTrash}
+              />
+            ))}
+          </tbody>
         </table>
       </div>
     </div>

--- a/src/entrypoints/popup/style.css
+++ b/src/entrypoints/popup/style.css
@@ -8,9 +8,8 @@
 
 body {
   width: var(--popup-width);
-  height: var(--popup-height);
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  max-height: var(--popup-height);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 14px;
   line-height: 1.4;
   margin: 0;

--- a/src/entrypoints/popup/style.css
+++ b/src/entrypoints/popup/style.css
@@ -9,7 +9,8 @@
 body {
   width: var(--popup-width);
   max-height: var(--popup-height);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 14px;
   line-height: 1.4;
   margin: 0;

--- a/tests/playground/playground-styles.css
+++ b/tests/playground/playground-styles.css
@@ -17,7 +17,7 @@ body {
 /* Popup simulator frame */
 .popup-frame {
   width: var(--popup-width);
-  height: var(--popup-height);
+  max-height: var(--popup-height);
   font-size: 14px;
   line-height: 1.4;
   background: white;


### PR DESCRIPTION
There's still an opportunity to improve the design of these states, but at least they aren't broken.

## Search results empty

<img width="597" height="164" alt="Screenshot 2025-09-29 at 3 16 24 PM" src="https://github.com/user-attachments/assets/8ad0c537-c80d-4151-93e6-0e900580e48d" />

## Completely empty

<img width="589" height="168" alt="Screenshot 2025-09-29 at 3 16 45 PM" src="https://github.com/user-attachments/assets/937960c2-98e6-4eeb-b343-9a1bbd4e35c3" />
