### PR TITLE
Prepare release infra for 1.0

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-const MODES = ["PROD", "PLAYGROUNDS_PR"] as const
+const MODES = ["PROD"] as const
 
 export type ModeType = (typeof MODES)[number]
 
@@ -8,6 +8,8 @@ export type LogLevel = (typeof LOG_LEVELS)[number]
 
 export const CONFIG = {
   EXTENSION_NAME: "gitcasso", // decorates logs
-  LOG_LEVEL: "DEBUG" satisfies LogLevel,
+  LOG_LEVEL: (import.meta.env.MODE === "production"
+    ? "WARN"
+    : "DEBUG") satisfies LogLevel,
   MODE: "PROD" satisfies ModeType,
 } as const

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       128: "/icons/icon-128.png",
     },
     name: "Gitcasso",
-    permissions: ["activeTab", "tabs"],
+    permissions: ["activeTab"],
     version: "0.2.0",
   },
   modules: ["@wxt-dev/webextension-polyfill"],


### PR DESCRIPTION
- we got rejected for not really needing the `tabs` permission
  - turns out they're right!
  - https://developer.chrome.com/docs/webstore/troubleshooting#misunderstood-perms-tabs
> - This permission ONLY grants access to the url, pendingUrl, title, or favIconUrl properties of Tab objects.
> - When is it required?
>   - When an extension does not have broad host access, but needs to be able to read sensitive data like the URL of an arbitrary tab.
> - When is it NOT required?
>   - When using methods on the [tabs](https://developer.chrome.com/docs/extensions/reference/tabs) API.
>   - When the extension has access to broad host permissions. Host permissions grant the extension access to the same > data as well as other capabilities.