### PR TITLE
Add/fix important kinds of GitHub highlighting 

### DIFF
--- a/src/lib/enhancers/github/github-common.ts
+++ b/src/lib/enhancers/github/github-common.ts
@@ -44,7 +44,7 @@ function escapeHtml(text: string): string {
     '"': "&quot;",
     "'": "&#39;",
   }
-  return text.replace(/[&<>"']/g, (m) => map[m])
+  return text.replace(/[&<>"']/g, (m) => map[m]!)
 }
 
 function githubHighlighter(code: string, language?: string) {

--- a/src/lib/enhancers/github/github-common.ts
+++ b/src/lib/enhancers/github/github-common.ts
@@ -36,16 +36,28 @@ export function prepareGitHubHighlighter() {
   })
 }
 
+function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }
+  return text.replace(/[&<>"']/g, (m) => map[m])
+}
+
 function githubHighlighter(code: string, language?: string) {
   try {
     if (language && hljs.getLanguage(language)) {
       const result = hljs.highlight(code, { language })
       return result.value
     } else {
-      return code
+      // No language specified - escape HTML to prevent tags from being interpreted
+      return escapeHtml(code)
     }
   } catch (error) {
     console.warn("highlight.js highlighting failed:", error)
-    return code
+    return escapeHtml(code)
   }
 }


### PR DESCRIPTION
- github-style #number links
- autolink https://someurl
- add highlighting for html tags e.g. `<img>` or `<details>`.